### PR TITLE
Fix error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ When reporting issues on GitHub, please include the full output from the diagnos
 
 ![xcodebuildmcp4](https://github.com/user-attachments/assets/17300a18-f47a-428a-aad3-dc094859c1b2)
 
-### Building and running iOS app in Claude Code
+### Building and running iOS app in Claude Desktop
 https://github.com/user-attachments/assets/e3c08d75-8be6-4857-b4d0-9350b26ef086
 
 ## Contributing


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change updates the section title from "Building and running iOS app in Claude Code" to "Building and running iOS app in Claude Desktop" to reflect the correct application name.

Unfortunately, as far as I can tell, XcodeBuildMCP is still not working in Claude Code 😩 Haven't heard back from them yet.