### PR TITLE
Support setting appearance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
   registerInstallAppInSimulatorTool,
   registerLaunchAppInSimulatorTool,
   registerLaunchAppWithLogsInSimulatorTool,
+  registerSetSimulatorAppearanceTool,
 } from './tools/simulator.js';
 
 // Import bundle ID tools
@@ -134,6 +135,7 @@ async function main(): Promise<void> {
     // Register Simulator management tools
     registerBootSimulatorTool(server);
     registerOpenSimulatorTool(server);
+    registerSetSimulatorAppearanceTool(server);
 
     // Register App installation and launch tools
     registerInstallAppInSimulatorTool(server);


### PR DESCRIPTION
Fix https://github.com/cameroncooke/XcodeBuildMCP/issues/26. This PR adds a tool for setting the simulator appearance (light/dark mode).

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/4fd5a12c-41cd-4599-9485-c3b75876e4d4" />
