### PR TITLE
Add debugging setup and deep link installation guide for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ src/version.ts
 # IDE and editor files
 .idea/
 .vscode/
+.vscode/*
+!.vscode/mcp.json
+!.vscode/launch.json
 *.swp
 *.swo
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "type": "node",
       "request": "attach",
-      "name": "Attach to MCP Server",
+      "name": "Attach to MCP Server Dev",
       "port": 9999,
       "restart": true,
       "skipFiles": [
@@ -12,7 +12,7 @@
       ],
       "sourceMaps": true,
       "outFiles": [
-        "${workspaceFolder}/build/**/*.js" // Add patterns for your compiled code
+        "${workspaceFolder}/build/**/*.js"
       ],
       "cwd": "${workspaceFolder}",
       "sourceMapPathOverrides": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to MCP Server",
+      "port": 9999,
+      "restart": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceFolder}/build/**/*.js" // Add patterns for your compiled code
+      ],
+      "cwd": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "/*": "${workspaceFolder}/src/*"
+      }
+    }
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,12 +1,15 @@
 {
     "servers": {
-        "my-mcp-server": {
+        "xcode-mcp-server-dev": {
             "type": "stdio",
             "command": "node",
             "args": [
                 "--inspect=9999",
                 "${workspaceFolder}/build/index.js"
-            ]
+            ],
+            "env": {
+                "XCODEBUILDMCP_DEBUG": "true"
+            }
         }
     }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+    "servers": {
+        "my-mcp-server": {
+            "type": "stdio",
+            "command": "node",
+            "args": [
+                "--inspect=9999",
+                "${workspaceFolder}/build/index.js"
+            ]
+        }
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,24 +64,12 @@ To configure your MCP client to use your local XcodeBuildMCP server you can use 
 
 VS Code is especially good for developing XcodeBuildMCP as it has a built-in way to view MCP client/server logs as well as the ability to configure MCP servers at a project level. It probably has the most comprehensive support for MCP development. 
 
-You can create a `.vscode/mcp.json` file in the root of the project with the following content:
+To make your development workflow in VS Code more efficient:
 
-```json
-{
-  "servers": {
-      "XcodeBuildMCP": {
-        "command": "node",
-        "args": [
-          "${workspaceFolder}/build/index.js"
-        ],
-        "env": {
-          "XCODEBUILDMCP_DEBUG": "true"
-        }
-      }
-  }
-}
-```
+1.  **Start the MCP Server**: Open the `.vscode/mcp.json` file. You can start the `xcode-mcp-server-dev` server either by clicking the `Start` CodeLens that appears above the server definition, or by opening the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`), running `Mcp: List Servers`, selecting `xcode-mcp-server-dev`, and starting the server.
+2.  **Launch the Debugger**: Press `F5` to attach the Node.js debugger.
 
+Once these steps are completed, you can utilize the tools from the MCP server you are developing within this repository in agent mode.
 For more details on how to work with MCP servers in VS Code see: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -120,7 +120,20 @@ Configure your MCP client (Windsurf, Cursor, Claude Desktop, etc.) to use the Xc
 
 #### One click to install in VS Code
 
-<!-- Note: update the version number in the URL to match the latest release version. -->
+<!-- Note: update the version number in the URL to match the latest release version.
+
+To generate 
+
+```
+let obj = {
+  "name": "XcodeBuildMCP",
+  "command": "mise",
+  "args": [ "x", "npm:xcodebuildmcp@1.3.7", "--", "xcodebuildmcp"]
+}
+
+// For Insiders, use `vscode-insiders` instead of `code`
+const link = encodeURIComponent(`vscode:mcp/install?${(JSON.stringify(obj))}`);
+``` -->
 
 [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22XcodeBuildMCP%22%2C%22command%22%3A%22mise%22%2C%22args%22%3A%5B%22x%22%2C%22npm%3Axcodebuildmcp%401.3.7%22%2C%22--%22%2C%22xcodebuildmcp%22%5D%7D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%7B%22name%22%3A%22XcodeBuildMCP%22%2C%22command%22%3A%22mise%22%2C%22args%22%3A%5B%22x%22%2C%22npm%3Axcodebuildmcp%401.3.7%22%2C%22--%22%2C%22xcodebuildmcp%22%5D%7D)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Configure your MCP client (Windsurf, Cursor, Claude Desktop, etc.) to use the Xc
 > [!IMPORTANT]
 > Please note that XcodeBuildMCP will request xcodebuild to skip macro validation. This is to avoid errors when building projects that use Swift Macros. 
 
+#### One click to install in VS Code
+
+<!-- Note: update the version number in the URL to match the latest release version. -->
+
+[<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22name%22%3A%22XcodeBuildMCP%22%2C%22command%22%3A%22mise%22%2C%22args%22%3A%5B%22x%22%2C%22npm%3Axcodebuildmcp%401.3.7%22%2C%22--%22%2C%22xcodebuildmcp%22%5D%7D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%7B%22name%22%3A%22XcodeBuildMCP%22%2C%22command%22%3A%22mise%22%2C%22args%22%3A%5B%22x%22%2C%22npm%3Axcodebuildmcp%401.3.7%22%2C%22--%22%2C%22xcodebuildmcp%22%5D%7D)
+
+
 ### Enabling UI Automation (beta)
 
 For UI automation features (tap, swipe, screenshot, etc.), you'll need to install Facebook's idb_companion:


### PR DESCRIPTION
This PR includes improvements for both contributors and end users:

- Adds `launch.json` and `mcp.json` to simplify debugging the MCP server in VS Code
  - Updates the contribution guide with instructions for launching and attaching to the MCP server
- Adds deep links to simplify MCP server installation directly from VS Code for end users

Here are recordings of how they work:

_Debug the server under development in VS Code_

https://github.com/user-attachments/assets/9a276f87-83cf-4367-8619-16a2c72f5bcb

_Install MCP server with deep link_

https://github.com/user-attachments/assets/c269d8bc-43a0-4954-9da2-2b4c7ccc54b7


