### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 A Model Context Protocol (MCP) server that provides Xcode-related tools for integration with AI assistants and other MCP clients.
 
-<a href="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP/badge" alt="XcodeBuildMCP MCP server" />
-</a>
-
 [![CI](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/ci.yml) [![CodeQL](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/github-code-scanning/codeql)
 [![Licence: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/e0f4ab6d-e867-4c6e-90cd-77363faaafcc)
@@ -319,5 +315,13 @@ See our [CONTRIBUTING](CONTRIBUTING.md) document for more information on how to 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## MCP Server Verification
+
+### Glama.ai
+
+<a href="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP/badge" alt="XcodeBuildMCP MCP server" />
+</a>
+
+### MseeP.a
 
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/cameroncooke-xcodebuildmcp-badge.png)](https://mseep.ai/app/cameroncooke-xcodebuildmcp)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides Xcode-related tools for integration with AI assistants and other MCP clients.
 
+<a href="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP/badge" alt="XcodeBuildMCP MCP server" />
+</a>
+
 [![CI](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/ci.yml/badge.svg)](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/ci.yml) [![CodeQL](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/cameroncooke/XcodeBuildMCP/actions/workflows/github-code-scanning/codeql)
 [![Licence: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/e0f4ab6d-e867-4c6e-90cd-77363faaafcc)


### PR DESCRIPTION
This PR adds a badge for the [XcodeBuildMCP](https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cameroncooke/XcodeBuildMCP/badge" alt="XcodeBuildMCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.