### PR TITLE
Refactor process execution

### DIFF
--- a/.windsurf/workflows/build-app.md
+++ b/.windsurf/workflows/build-app.md
@@ -2,6 +2,6 @@
 description: Build and run the app on the iOS simulator
 ---
 
-1. Build the app
+1. Build the iOS app
 2. Run the app on the simulator
-3. Only use tools exposed by XcodeBuildMCP
+3. Only use tools exposed by "xcode-mcp-server-dev"

--- a/src/tools/app_path.ts
+++ b/src/tools/app_path.ts
@@ -16,7 +16,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from '../utils/logger.js';
 import { validateRequiredParam, createTextResponse } from '../utils/validation.js';
 import { ToolResponse, XcodePlatform } from '../types/common.js';
-import { executeXcodeCommand, constructDestinationString } from '../utils/xcode.js';
+import { executeCommand } from '../utils/command.js';
+import { constructDestinationString } from '../utils/xcode.js';
 import {
   registerTool,
   workspacePathSchema,
@@ -117,7 +118,7 @@ async function _handleGetAppPathLogic(params: {
     command.push('-destination', destinationString);
 
     // Execute the command directly
-    const result = await executeXcodeCommand(command, 'Get App Path');
+    const result = await executeCommand(command, 'Get App Path');
 
     if (!result.success) {
       return createTextResponse(`Failed to get app path: ${result.error}`, true);

--- a/src/tools/build_ios_device.ts
+++ b/src/tools/build_ios_device.ts
@@ -14,7 +14,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { XcodePlatform } from '../utils/xcode.js';
 import { validateRequiredParam } from '../utils/validation.js';
-import { executeXcodeBuild } from '../utils/build-utils.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
 import {
   registerTool,
   workspacePathSchema,
@@ -54,7 +54,7 @@ export function registerIOSDeviceBuildWorkspaceTool(server: McpServer): void {
       const schemeValidation = validateRequiredParam('scheme', params.scheme);
       if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
 
-      return executeXcodeBuild(
+      return executeXcodeBuildCommand(
         {
           ...params,
           configuration: params.configuration ?? 'Debug', // Default config
@@ -94,7 +94,7 @@ export function registerIOSDeviceBuildProjectTool(server: McpServer): void {
       const schemeValidation = validateRequiredParam('scheme', params.scheme);
       if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
 
-      return executeXcodeBuild(
+      return executeXcodeBuildCommand(
         {
           ...params,
           configuration: params.configuration ?? 'Debug', // Default config

--- a/src/tools/build_ios_simulator.ts
+++ b/src/tools/build_ios_simulator.ts
@@ -14,10 +14,11 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from '../utils/logger.js';
-import { XcodePlatform, executeXcodeCommand } from '../utils/xcode.js';
+import { XcodePlatform } from '../utils/xcode.js';
+import { executeCommand } from '../utils/command.js';
 import { validateRequiredParam, createTextResponse } from '../utils/validation.js';
 import { ToolResponse } from '../types/common.js';
-import { executeXcodeBuild } from '../utils/build-utils.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
 import {
   registerTool,
   workspacePathSchema,
@@ -52,7 +53,7 @@ async function _handleIOSSimulatorBuildLogic(params: {
 }): Promise<ToolResponse> {
   log('info', `Starting iOS Simulator build for scheme ${params.scheme} (internal)`);
 
-  return executeXcodeBuild(
+  return executeXcodeBuildCommand(
     {
       ...params,
     },
@@ -134,7 +135,7 @@ async function _handleIOSSimulatorBuildAndRunLogic(params: {
     }
 
     // Execute the command directly
-    const result = await executeXcodeCommand(command, 'Get App Path');
+    const result = await executeCommand(command, 'Get App Path');
 
     // If there was an error with the command execution, return it
     if (!result.success) {

--- a/src/tools/build_macos.ts
+++ b/src/tools/build_macos.ts
@@ -16,10 +16,11 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { log } from '../utils/logger.js';
-import { XcodePlatform, executeXcodeCommand } from '../utils/xcode.js';
+import { XcodePlatform } from '../utils/xcode.js';
+import { executeCommand } from '../utils/command.js';
 import { createTextResponse } from '../utils/validation.js';
 import { ToolResponse } from '../types/common.js';
-import { executeXcodeBuild } from '../utils/build-utils.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
 import { z } from 'zod';
 import {
   registerTool,
@@ -55,7 +56,7 @@ async function _handleMacOSBuildLogic(params: {
 }): Promise<ToolResponse> {
   log('info', `Starting macOS build for scheme ${params.scheme} (internal)`);
 
-  return executeXcodeBuild(
+  return executeXcodeBuildCommand(
     {
       ...params,
     },
@@ -104,7 +105,7 @@ async function _getAppPathFromBuildSettings(params: {
     }
 
     // Execute the command directly
-    const result = await executeXcodeCommand(command, 'Get Build Settings for Launch');
+    const result = await executeCommand(command, 'Get Build Settings for Launch');
 
     if (!result.success) {
       return {

--- a/src/tools/build_settings.ts
+++ b/src/tools/build_settings.ts
@@ -14,7 +14,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from '../utils/logger.js';
-import { executeXcodeCommand } from '../utils/xcode.js';
+import { executeCommand } from '../utils/command.js';
 import { validateRequiredParam, createTextResponse } from '../utils/validation.js';
 import { ToolResponse } from '../types/common.js';
 import {
@@ -53,7 +53,7 @@ async function _handleShowBuildSettingsLogic(params: {
     command.push('-scheme', params.scheme);
 
     // Execute the command directly
-    const result = await executeXcodeCommand(command, 'Show Build Settings');
+    const result = await executeCommand(command, 'Show Build Settings');
 
     if (!result.success) {
       return createTextResponse(`Failed to show build settings: ${result.error}`, true);
@@ -98,7 +98,7 @@ async function _handleListSchemesLogic(params: {
       command.push('-project', params.projectPath);
     } // No else needed, one path is guaranteed by callers
 
-    const result = await executeXcodeCommand(command, 'List Schemes');
+    const result = await executeCommand(command, 'List Schemes');
 
     if (!result.success) {
       return createTextResponse(`Failed to list schemes: ${result.error}`, true);

--- a/src/tools/clean.ts
+++ b/src/tools/clean.ts
@@ -17,7 +17,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { log } from '../utils/logger.js';
 import { XcodePlatform } from '../utils/xcode.js';
 import { ToolResponse } from '../types/common.js';
-import { executeXcodeBuild } from '../utils/build-utils.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
 
 // --- Private Helper Function ---
 
@@ -35,7 +35,7 @@ async function _handleCleanLogic(params: {
   log('info', 'Starting xcodebuild clean request (internal)');
 
   // For clean operations, we need to provide a default platform and configuration
-  return executeXcodeBuild(
+  return executeXcodeBuildCommand(
     {
       ...params,
       scheme: params.scheme || '', // Empty string if not provided

--- a/src/tools/simulator.ts
+++ b/src/tools/simulator.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { execSync } from 'child_process';
 import { log } from '../utils/logger.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { executeXcodeCommand } from '../utils/xcode.js';
+import { executeCommand } from '../utils/command.js';
 import { validateRequiredParam, validateFileExists } from '../utils/validation.js';
 import { ToolResponse } from '../types/common.js';
 import { createTextContent } from './common.js';
@@ -45,7 +45,7 @@ export function registerBootSimulatorTool(server: McpServer): void {
 
       try {
         const command = ['xcrun', 'simctl', 'boot', params.simulatorUuid];
-        const result = await executeXcodeCommand(command, 'Boot Simulator');
+        const result = await executeCommand(command, 'Boot Simulator');
 
         if (!result.success) {
           return {
@@ -104,7 +104,7 @@ export function registerListSimulatorsTool(server: McpServer): void {
 
       try {
         const command = ['xcrun', 'simctl', 'list', 'devices', 'available', '--json'];
-        const result = await executeXcodeCommand(command, 'List Simulators');
+        const result = await executeCommand(command, 'List Simulators');
 
         if (!result.success) {
           return {
@@ -211,7 +211,7 @@ export function registerInstallAppInSimulatorTool(server: McpServer): void {
 
       try {
         const command = ['xcrun', 'simctl', 'install', params.simulatorUuid, params.appPath];
-        const result = await executeXcodeCommand(command, 'Install App in Simulator');
+        const result = await executeCommand(command, 'Install App in Simulator');
 
         if (!result.success) {
           return {
@@ -299,7 +299,7 @@ export function registerLaunchAppInSimulatorTool(server: McpServer): void {
           params.bundleId,
           'app',
         ];
-        const getAppContainerResult = await executeXcodeCommand(
+        const getAppContainerResult = await executeCommand(
           getAppContainerCmd,
           'Check App Installed',
         );
@@ -333,7 +333,7 @@ export function registerLaunchAppInSimulatorTool(server: McpServer): void {
           command.push(...params.args);
         }
 
-        const result = await executeXcodeCommand(command, 'Launch App in Simulator');
+        const result = await executeCommand(command, 'Launch App in Simulator');
 
         if (!result.success) {
           return {
@@ -446,7 +446,7 @@ export function registerOpenSimulatorTool(server: McpServer): void {
 
       try {
         const command = ['open', '-a', 'Simulator'];
-        const result = await executeXcodeCommand(command, 'Open Simulator');
+        const result = await executeCommand(command, 'Open Simulator');
 
         if (!result.success) {
           return {
@@ -523,7 +523,7 @@ async function executeSimctlCommandAndRespond(
 
   try {
     const command = ['xcrun', 'simctl', ...simctlSubCommand];
-    const result = await executeXcodeCommand(command, operationDescriptionForXcodeCommand);
+    const result = await executeCommand(command, operationDescriptionForXcodeCommand);
 
     if (!result.success) {
       const fullFailureMessage = `${failureMessagePrefix}: ${result.error}`;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -73,11 +73,6 @@ export interface CommandResponse {
 }
 
 /**
- * XcodeCommandResponse - Result of xcodebuild command execution
- */
-export type XcodeCommandResponse = CommandResponse;
-
-/**
  * Interface for shared build parameters
  */
 export interface SharedBuildParams {

--- a/src/utils/build-utils.ts
+++ b/src/utils/build-utils.ts
@@ -18,7 +18,8 @@
  */
 
 import { log } from './logger.js';
-import { executeXcodeCommand, XcodePlatform, constructDestinationString } from './xcode.js';
+import { XcodePlatform, constructDestinationString } from './xcode.js';
+import { executeCommand } from './command.js';
 import { ToolResponse, SharedBuildParams, PlatformBuildOptions } from '../types/common.js';
 import { createTextResponse } from './validation.js';
 import {
@@ -39,7 +40,7 @@ import path from 'path';
  * @param buildAction The xcodebuild action to perform (e.g., 'build', 'clean', 'test')
  * @returns Promise resolving to tool response
  */
-export async function executeXcodeBuild(
+export async function executeXcodeBuildCommand(
   params: SharedBuildParams,
   platformOptions: PlatformBuildOptions,
   preferXcodebuild: boolean = false,
@@ -206,7 +207,7 @@ export async function executeXcodeBuild(
       }
     } else {
       // Use standard xcodebuild
-      result = await executeXcodeCommand(command, platformOptions.logPrefix);
+      result = await executeCommand(command, platformOptions.logPrefix);
     }
 
     // Grep warnings and errors from stdout (build output)

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -9,7 +9,7 @@
  * - Managing process spawning, output capture, and error handling
  */
 
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import { log } from './logger.js';
 
 /**
@@ -19,18 +19,50 @@ export interface CommandResponse {
   success: boolean;
   output: string;
   error?: string;
+  process: ChildProcess;
 }
 
 /**
- * Execute a shell command
- * @param command Command string to execute
- * @returns Promise resolving to command response
+ * Execute a command
+ * @param command An array of command and arguments
+ * @param logPrefix Prefix for logging
+ * @param useShell Whether to use shell execution (true) or direct execution (false)
+ * @returns Promise resolving to command response with the process
  */
-export async function executeCommand(command: string): Promise<CommandResponse> {
-  log('info', `Executing command: ${command}`);
+export async function executeCommand(
+  command: string[],
+  logPrefix?: string,
+  useShell: boolean = true,
+): Promise<CommandResponse> {
+  // Properly escape arguments for shell
+  let escapedCommand = command;
+  if (useShell) {
+    // For shell execution, we need to format as ['sh', '-c', 'full command string']
+    const commandString = command
+      .map((arg) => {
+        // If the argument contains spaces or special characters, wrap it in quotes
+        // Ensure existing quotes are escaped
+        if (/[\s,"'=]/.test(arg) && !/^".*"$/.test(arg)) {
+          // Check if needs quoting and isn't already quoted
+          return `"${arg.replace(/(["\\])/g, '\\$1')}"`; // Escape existing quotes and backslashes
+        }
+        return arg;
+      })
+      .join(' ');
+
+    escapedCommand = ['sh', '-c', commandString];
+  }
+
+  // Log the actual command that will be executed
+  const displayCommand =
+    useShell && escapedCommand.length === 3 ? escapedCommand[2] : escapedCommand.join(' ');
+  log('info', `Executing ${logPrefix || ''} command: ${displayCommand}`);
 
   return new Promise((resolve, reject) => {
-    const process = spawn('sh', ['-c', command], {
+    const executable = escapedCommand[0];
+    const args = escapedCommand.slice(1);
+
+    const process = spawn(executable, args, {
       stdio: ['ignore', 'pipe', 'pipe'], // ignore stdin, pipe stdout/stderr
     });
 
@@ -51,6 +83,7 @@ export async function executeCommand(command: string): Promise<CommandResponse> 
         success,
         output: stdout,
         error: success ? undefined : stderr,
+        process,
       };
 
       resolve(response);


### PR DESCRIPTION
Refactor process execution functions to use a single unified `executeCommand` function, this can be used directly for basic shell commands. For `xcodebuild ... build|test` etc commands `executeXcodeBuildCommand` should be preferred which calls the lower level `executeCommand` to spaw then `xcodebuild` process.