### PR TITLE
Add comprehensive iOS testing and device management tools

### DIFF
--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -1,0 +1,231 @@
+/**
+ * iOS Device Tools - Functions for working with physical iOS devices
+ *
+ * This module provides tools for discovering and interacting with physical iOS devices
+ * through xcrun devicectl and xcrun xctrace commands.
+ *
+ * Responsibilities:
+ * - Listing connected iOS devices with their UUIDs, names, and properties
+ * - Supporting both modern devicectl and legacy xctrace commands for compatibility
+ * - Providing device information for testing and deployment workflows
+ */
+
+import { z } from 'zod';
+import { log } from '../utils/logger.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { executeCommand } from '../utils/command.js';
+import { ToolResponse } from '../types/common.js';
+import { registerTool } from './common.js';
+
+/**
+ * Lists available iOS devices with their UUIDs and properties
+ */
+export function registerListIOSDevicesTool(server: McpServer): void {
+  registerTool(
+    server,
+    'list_ios_devices',
+    'Lists connected iOS devices with their UUIDs, names, and connection status. Use this to discover devices for testing.',
+    {
+      includeSimulators: z.boolean().optional().describe('Include simulators in the list (default: false)'),
+    },
+    async (params: { includeSimulators?: boolean }): Promise<ToolResponse> => {
+      log('info', 'Starting iOS device discovery');
+
+      try {
+        // Try modern devicectl first (iOS 17+, Xcode 15+)
+        let result = await executeCommand(['xcrun', 'devicectl', 'list', 'devices'], 'List iOS Devices (devicectl)');
+        let useDevicectl = result.success;
+
+        if (!result.success) {
+          log('info', 'devicectl failed, trying xctrace fallback');
+          // Fallback to xctrace for older Xcode versions
+          result = await executeCommand(['xcrun', 'xctrace', 'list', 'devices'], 'List iOS Devices (xctrace)');
+          useDevicectl = false;
+        }
+
+        if (!result.success) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Failed to list iOS devices: ${result.error}\n\nMake sure Xcode is installed and devices are connected and trusted.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Parse the output based on which command was used
+        let responseText = 'Connected iOS Devices:\n\n';
+        const devices: Array<{
+          name: string;
+          identifier: string;
+          platform: string;
+          version?: string;
+          state?: string;
+        }> = [];
+
+        if (useDevicectl) {
+          // Parse devicectl output - it's a tabular format with columns:
+          // Name, Hostname, Identifier, State, Model
+          const lines = result.output.split('\n');
+          let headerFound = false;
+
+          for (const line of lines) {
+            const trimmedLine = line.trim();
+            
+            // Skip empty lines
+            if (!trimmedLine) continue;
+            
+            // Skip header lines and separator lines
+            if (trimmedLine.includes('Name') && trimmedLine.includes('Identifier')) {
+              headerFound = true;
+              continue;
+            }
+            if (trimmedLine.match(/^-+\s+-+\s+-+/)) {
+              continue;
+            }
+            
+            // Only process device lines after we've seen the header
+            if (!headerFound) continue;
+            
+            // Parse tabular format - split by multiple spaces to separate columns
+            const columns = trimmedLine.split(/\s{2,}/);
+            if (columns.length >= 4) {
+              const [name, hostname, identifier, state, ...modelParts] = columns;
+              const model = modelParts.join(' ');
+              
+              // Only include devices that are connected or available
+              if (state && (state.includes('connected') || state.includes('available'))) {
+                // Filter out non-iOS devices (HomePods, etc.)
+                if (!model.toLowerCase().includes('homepod') && 
+                    !model.toLowerCase().includes('homeaccessory') &&
+                    !model.toLowerCase().includes('vmac')) {
+                  
+                  devices.push({
+                    name: name.trim(),
+                    identifier: identifier.trim(),
+                    platform: 'iOS',
+                    state: state.trim(),
+                    version: model.trim()
+                  });
+                }
+              }
+            }
+          }
+        } else {
+          // Parse xctrace output
+          const lines = result.output.split('\n');
+          
+          for (const line of lines) {
+            const trimmedLine = line.trim();
+            
+            // Skip headers and empty lines
+            if (!trimmedLine || trimmedLine.includes('== Devices ==') || trimmedLine.includes('== Simulators ==')) {
+              continue;
+            }
+            
+            // Skip simulators unless requested
+            if (!params.includeSimulators && (trimmedLine.toLowerCase().includes('simulator') || trimmedLine.includes('iOS Simulator'))) {
+              continue;
+            }
+            
+            // Parse device line format from xctrace
+            // Typical format: "Device Name (iOS Version) [Device ID]" or variations
+            const deviceMatch = trimmedLine.match(/^(.+?)\s*\(([^)]+)\)\s*(?:\[([A-F0-9-]+)\])?/);
+            if (deviceMatch) {
+              const [, name, versionInfo, identifier] = deviceMatch;
+              
+              // Skip if it's clearly a simulator and we don't want simulators
+              if (!params.includeSimulators && name.toLowerCase().includes('simulator')) {
+                continue;
+              }
+              
+              devices.push({
+                name: name.trim(),
+                identifier: identifier || 'Unknown',
+                platform: versionInfo.includes('iOS') ? 'iOS' : 'Unknown',
+                version: versionInfo,
+                state: 'Connected'
+              });
+            }
+          }
+        }
+
+        // Filter out duplicates and format response
+        const uniqueDevices = devices.filter((device, index, self) => 
+          index === self.findIndex(d => d.identifier === device.identifier)
+        );
+
+        if (uniqueDevices.length === 0) {
+          responseText += 'No iOS devices found.\n\n';
+          responseText += 'Make sure:\n';
+          responseText += '1. iOS devices are connected via USB\n';
+          responseText += '2. Devices are unlocked and trusted\n';
+          responseText += '3. "Trust this computer" has been accepted on the device\n';
+          responseText += '4. Xcode is properly installed\n';
+        } else {
+          // Group devices by platform
+          const iosDevices = uniqueDevices.filter(d => d.platform === 'iOS' && !d.name.toLowerCase().includes('simulator'));
+          
+          if (iosDevices.length > 0) {
+            responseText += 'Physical iOS Devices:\n';
+            for (const device of iosDevices) {
+              responseText += `- ${device.name}`;
+              if (device.version) {
+                responseText += ` (${device.version})`;
+              }
+              responseText += ` [${device.identifier}]`;
+              if (device.state) {
+                responseText += ` - ${device.state}`;
+              }
+              responseText += '\n';
+            }
+            responseText += '\n';
+          }
+          
+          // Include simulators if requested
+          if (params.includeSimulators) {
+            const simulators = uniqueDevices.filter(d => d.name.toLowerCase().includes('simulator'));
+            if (simulators.length > 0) {
+              responseText += 'Simulators:\n';
+              for (const device of simulators) {
+                responseText += `- ${device.name} [${device.identifier}]\n`;
+              }
+              responseText += '\n';
+            }
+          }
+        }
+
+        // Add next steps
+        if (uniqueDevices.filter(d => d.platform === 'iOS' && !d.name.toLowerCase().includes('simulator')).length > 0) {
+          responseText += 'Next Steps:\n';
+          responseText += "1. Run tests on device: test_ios_dev_ws({ workspacePath: 'PATH', scheme: 'SCHEME', deviceId: 'DEVICE_ID_FROM_ABOVE' })\n";
+          responseText += "2. Build for device: build_ios_dev_ws({ workspacePath: 'PATH', scheme: 'SCHEME' })\n";
+          responseText += "3. Get app path: get_ios_dev_app_path_ws({ workspacePath: 'PATH', scheme: 'SCHEME' })\n";
+        }
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: responseText,
+            },
+          ],
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        log('error', `Error listing iOS devices: ${errorMessage}`);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Failed to list iOS devices: ${errorMessage}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/tools/test_ios_device.ts
+++ b/src/tools/test_ios_device.ts
@@ -1,0 +1,237 @@
+/**
+ * iOS Device Test Tools - Tools for running tests on physical iOS devices
+ *
+ * This module provides specialized tools for running unit tests and UI tests on physical iOS devices
+ * using xcodebuild test. It supports both workspace and project-based testing.
+ *
+ * Responsibilities:
+ * - Running tests on connected iOS devices from project files and workspaces
+ * - Handling test configuration and result collection
+ * - Supporting test plans, specific test classes, and test methods
+ * - Code coverage collection and test result bundle handling
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { XcodePlatform } from '../utils/xcode.js';
+import { validateRequiredParam } from '../utils/validation.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
+import {
+  registerTool,
+  workspacePathSchema,
+  projectPathSchema,
+  schemeSchema,
+  configurationSchema,
+  derivedDataPathSchema,
+  extraArgsSchema,
+  preferXcodebuildSchema,
+} from './common.js';
+
+// Test-specific parameter schemas
+const testPlanSchema = z.string().optional().describe('Optional test plan to run');
+const testClassSchema = z.string().optional().describe('Optional specific test class to run');
+const testMethodSchema = z.string().optional().describe('Optional specific test method to run');
+const codeCoverageSchema = z.boolean().optional().describe('Enable code coverage collection (default: false)');
+const resultBundlePathSchema = z.string().optional().describe('Custom path for test result bundle (.xcresult)');
+const retryOnFailureSchema = z.boolean().optional().describe('Retry failed tests (default: false)');
+const deviceIdSchema = z.string().optional().describe('Optional specific device ID to target (if multiple devices connected)');
+
+// --- iOS Device Test Tools ---
+
+/**
+ * Registers the test_ios_dev_ws tool
+ */
+export function registerIOSDeviceTestWorkspaceTool(server: McpServer): void {
+  type Params = {
+    workspacePath: string;
+    scheme: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+    deviceId?: string;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_dev_ws',
+    "Runs tests on a physical iOS device from a workspace. IMPORTANT: Requires workspacePath and scheme. Device must be connected and trusted. Example: test_ios_dev_ws({ workspacePath: '/path/to/MyProject.xcworkspace', scheme: 'MyScheme' })",
+    {
+      workspacePath: workspacePathSchema,
+      scheme: schemeSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+      deviceId: deviceIdSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const workspaceValidation = validateRequiredParam('workspacePath', params.workspacePath);
+      if (!workspaceValidation.isValid) return workspaceValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      // Add device-specific destination if deviceId provided
+      if (params.deviceId) {
+        testExtraArgs.push('-destination', `platform=iOS,id=${params.deviceId}`);
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOS,
+          logPrefix: 'iOS Device Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+/**
+ * Registers the test_ios_dev_proj tool
+ */
+export function registerIOSDeviceTestProjectTool(server: McpServer): void {
+  type Params = {
+    projectPath: string;
+    scheme: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+    deviceId?: string;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_dev_proj',
+    "Runs tests on a physical iOS device from a project file. IMPORTANT: Requires projectPath and scheme. Device must be connected and trusted. Example: test_ios_dev_proj({ projectPath: '/path/to/MyProject.xcodeproj', scheme: 'MyScheme' })",
+    {
+      projectPath: projectPathSchema,
+      scheme: schemeSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+      deviceId: deviceIdSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const projectValidation = validateRequiredParam('projectPath', params.projectPath);
+      if (!projectValidation.isValid) return projectValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      // Add device-specific destination if deviceId provided
+      if (params.deviceId) {
+        testExtraArgs.push('-destination', `platform=iOS,id=${params.deviceId}`);
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOS,
+          logPrefix: 'iOS Device Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+// Register all iOS device test tools
+export function registerIOSDeviceTestTools(server: McpServer): void {
+  registerIOSDeviceTestWorkspaceTool(server);
+  registerIOSDeviceTestProjectTool(server);
+}

--- a/src/tools/test_ios_simulator.ts
+++ b/src/tools/test_ios_simulator.ts
@@ -1,0 +1,444 @@
+/**
+ * iOS Simulator Test Tools - Tools for running tests on iOS simulators
+ *
+ * This module provides specialized tools for running unit tests and UI tests on iOS simulators
+ * using xcodebuild test. It supports both workspace and project-based testing with simulator 
+ * targeting by name or UUID.
+ *
+ * Responsibilities:
+ * - Running tests on iOS simulators from project files and workspaces
+ * - Supporting simulator targeting by name or UUID
+ * - Handling test configuration and result collection
+ * - Supporting test plans, specific test classes, and test methods
+ * - Code coverage collection and test result bundle handling
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { log } from '../utils/logger.js';
+import { XcodePlatform } from '../utils/xcode.js';
+import { validateRequiredParam } from '../utils/validation.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
+import {
+  registerTool,
+  workspacePathSchema,
+  projectPathSchema,
+  schemeSchema,
+  configurationSchema,
+  derivedDataPathSchema,
+  extraArgsSchema,
+  simulatorNameSchema,
+  simulatorIdSchema,
+  useLatestOSSchema,
+  preferXcodebuildSchema,
+} from './common.js';
+
+// Test-specific parameter schemas
+const testPlanSchema = z.string().optional().describe('Optional test plan to run');
+const testClassSchema = z.string().optional().describe('Optional specific test class to run');
+const testMethodSchema = z.string().optional().describe('Optional specific test method to run');
+const codeCoverageSchema = z.boolean().optional().describe('Enable code coverage collection (default: false)');
+const resultBundlePathSchema = z.string().optional().describe('Custom path for test result bundle (.xcresult)');
+const retryOnFailureSchema = z.boolean().optional().describe('Retry failed tests (default: false)');
+
+// --- iOS Simulator Test Tools ---
+
+/**
+ * Registers the test_ios_sim_name_ws tool
+ */
+export function registerIOSSimulatorTestByNameWorkspaceTool(server: McpServer): void {
+  type Params = {
+    workspacePath: string;
+    scheme: string;
+    simulatorName: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    useLatestOS?: boolean;
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_sim_name_ws',
+    "Runs tests on an iOS simulator from a workspace, targeting simulator by name. IMPORTANT: Requires workspacePath, scheme, and simulatorName. Example: test_ios_sim_name_ws({ workspacePath: '/path/to/MyProject.xcworkspace', scheme: 'MyScheme', simulatorName: 'iPhone 16' })",
+    {
+      workspacePath: workspacePathSchema,
+      scheme: schemeSchema,
+      simulatorName: simulatorNameSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      useLatestOS: useLatestOSSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const workspaceValidation = validateRequiredParam('workspacePath', params.workspacePath);
+      if (!workspaceValidation.isValid) return workspaceValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      const simulatorNameValidation = validateRequiredParam('simulatorName', params.simulatorName);
+      if (!simulatorNameValidation.isValid) return simulatorNameValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOSSimulator,
+          simulatorName: params.simulatorName,
+          useLatestOS: params.useLatestOS ?? true,
+          logPrefix: 'iOS Simulator Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+/**
+ * Registers the test_ios_sim_name_proj tool
+ */
+export function registerIOSSimulatorTestByNameProjectTool(server: McpServer): void {
+  type Params = {
+    projectPath: string;
+    scheme: string;
+    simulatorName: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    useLatestOS?: boolean;
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_sim_name_proj',
+    "Runs tests on an iOS simulator from a project file, targeting simulator by name. IMPORTANT: Requires projectPath, scheme, and simulatorName. Example: test_ios_sim_name_proj({ projectPath: '/path/to/MyProject.xcodeproj', scheme: 'MyScheme', simulatorName: 'iPhone 16' })",
+    {
+      projectPath: projectPathSchema,
+      scheme: schemeSchema,
+      simulatorName: simulatorNameSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      useLatestOS: useLatestOSSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const projectValidation = validateRequiredParam('projectPath', params.projectPath);
+      if (!projectValidation.isValid) return projectValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      const simulatorNameValidation = validateRequiredParam('simulatorName', params.simulatorName);
+      if (!simulatorNameValidation.isValid) return simulatorNameValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOSSimulator,
+          simulatorName: params.simulatorName,
+          useLatestOS: params.useLatestOS ?? true,
+          logPrefix: 'iOS Simulator Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+/**
+ * Registers the test_ios_sim_id_ws tool
+ */
+export function registerIOSSimulatorTestByIdWorkspaceTool(server: McpServer): void {
+  type Params = {
+    workspacePath: string;
+    scheme: string;
+    simulatorId: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    useLatestOS?: boolean;
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_sim_id_ws',
+    "Runs tests on an iOS simulator from a workspace, targeting simulator by UUID. IMPORTANT: Requires workspacePath, scheme, and simulatorId. Example: test_ios_sim_id_ws({ workspacePath: '/path/to/MyProject.xcworkspace', scheme: 'MyScheme', simulatorId: 'SIMULATOR_UUID' })",
+    {
+      workspacePath: workspacePathSchema,
+      scheme: schemeSchema,
+      simulatorId: simulatorIdSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      useLatestOS: useLatestOSSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const workspaceValidation = validateRequiredParam('workspacePath', params.workspacePath);
+      if (!workspaceValidation.isValid) return workspaceValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      const simulatorIdValidation = validateRequiredParam('simulatorId', params.simulatorId);
+      if (!simulatorIdValidation.isValid) return simulatorIdValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOSSimulator,
+          simulatorId: params.simulatorId,
+          useLatestOS: params.useLatestOS ?? true,
+          logPrefix: 'iOS Simulator Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+/**
+ * Registers the test_ios_sim_id_proj tool
+ */
+export function registerIOSSimulatorTestByIdProjectTool(server: McpServer): void {
+  type Params = {
+    projectPath: string;
+    scheme: string;
+    simulatorId: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    useLatestOS?: boolean;
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+  };
+
+  registerTool<Params>(
+    server,
+    'test_ios_sim_id_proj',
+    "Runs tests on an iOS simulator from a project file, targeting simulator by UUID. IMPORTANT: Requires projectPath, scheme, and simulatorId. Example: test_ios_sim_id_proj({ projectPath: '/path/to/MyProject.xcodeproj', scheme: 'MyScheme', simulatorId: 'SIMULATOR_UUID' })",
+    {
+      projectPath: projectPathSchema,
+      scheme: schemeSchema,
+      simulatorId: simulatorIdSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      useLatestOS: useLatestOSSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const projectValidation = validateRequiredParam('projectPath', params.projectPath);
+      if (!projectValidation.isValid) return projectValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      const simulatorIdValidation = validateRequiredParam('simulatorId', params.simulatorId);
+      if (!simulatorIdValidation.isValid) return simulatorIdValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.iOSSimulator,
+          simulatorId: params.simulatorId,
+          useLatestOS: params.useLatestOS ?? true,
+          logPrefix: 'iOS Simulator Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+// Register all iOS simulator test tools
+export function registerIOSSimulatorTestTools(server: McpServer): void {
+  registerIOSSimulatorTestByNameWorkspaceTool(server);
+  registerIOSSimulatorTestByNameProjectTool(server);
+  registerIOSSimulatorTestByIdWorkspaceTool(server);
+  registerIOSSimulatorTestByIdProjectTool(server);
+}

--- a/src/tools/test_macos.ts
+++ b/src/tools/test_macos.ts
@@ -1,0 +1,238 @@
+/**
+ * macOS Test Tools - Tools for running tests on macOS
+ *
+ * This module provides specialized tools for running unit tests and UI tests on macOS
+ * using xcodebuild test. It supports both workspace and project-based testing.
+ *
+ * Responsibilities:
+ * - Running tests on macOS from project files and workspaces
+ * - Handling test configuration and result collection
+ * - Supporting test plans, specific test classes, and test methods
+ * - Code coverage collection and test result bundle handling
+ * - Supporting different macOS architectures (Intel/Apple Silicon)
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { XcodePlatform } from '../utils/xcode.js';
+import { validateRequiredParam } from '../utils/validation.js';
+import { executeXcodeBuildCommand } from '../utils/build-utils.js';
+import {
+  registerTool,
+  workspacePathSchema,
+  projectPathSchema,
+  schemeSchema,
+  configurationSchema,
+  derivedDataPathSchema,
+  extraArgsSchema,
+  preferXcodebuildSchema,
+} from './common.js';
+
+// Test-specific parameter schemas
+const testPlanSchema = z.string().optional().describe('Optional test plan to run');
+const testClassSchema = z.string().optional().describe('Optional specific test class to run');
+const testMethodSchema = z.string().optional().describe('Optional specific test method to run');
+const codeCoverageSchema = z.boolean().optional().describe('Enable code coverage collection (default: false)');
+const resultBundlePathSchema = z.string().optional().describe('Custom path for test result bundle (.xcresult)');
+const retryOnFailureSchema = z.boolean().optional().describe('Retry failed tests (default: false)');
+const archSchema = z.enum(['arm64', 'x86_64']).optional().describe('Architecture to test for (arm64 or x86_64). For macOS only.');
+
+// --- macOS Test Tools ---
+
+/**
+ * Registers the test_mac_ws tool
+ */
+export function registerMacOSTestWorkspaceTool(server: McpServer): void {
+  type Params = {
+    workspacePath: string;
+    scheme: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+    arch?: 'arm64' | 'x86_64';
+  };
+
+  registerTool<Params>(
+    server,
+    'test_mac_ws',
+    "Runs tests on macOS from a workspace. IMPORTANT: Requires workspacePath and scheme. Example: test_mac_ws({ workspacePath: '/path/to/MyProject.xcworkspace', scheme: 'MyScheme' })",
+    {
+      workspacePath: workspacePathSchema,
+      scheme: schemeSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+      arch: archSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const workspaceValidation = validateRequiredParam('workspacePath', params.workspacePath);
+      if (!workspaceValidation.isValid) return workspaceValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      // Add architecture-specific destination if arch provided
+      if (params.arch) {
+        testExtraArgs.push('-destination', `platform=macOS,arch=${params.arch}`);
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.macOS,
+          logPrefix: 'macOS Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+/**
+ * Registers the test_mac_proj tool
+ */
+export function registerMacOSTestProjectTool(server: McpServer): void {
+  type Params = {
+    projectPath: string;
+    scheme: string;
+    configuration?: string;
+    derivedDataPath?: string;
+    extraArgs?: string[];
+    preferXcodebuild?: boolean;
+    testPlan?: string;
+    testClass?: string;
+    testMethod?: string;
+    codeCoverage?: boolean;
+    resultBundlePath?: string;
+    retryOnFailure?: boolean;
+    arch?: 'arm64' | 'x86_64';
+  };
+
+  registerTool<Params>(
+    server,
+    'test_mac_proj',
+    "Runs tests on macOS from a project file. IMPORTANT: Requires projectPath and scheme. Example: test_mac_proj({ projectPath: '/path/to/MyProject.xcodeproj', scheme: 'MyScheme' })",
+    {
+      projectPath: projectPathSchema,
+      scheme: schemeSchema,
+      configuration: configurationSchema,
+      derivedDataPath: derivedDataPathSchema,
+      extraArgs: extraArgsSchema,
+      preferXcodebuild: preferXcodebuildSchema,
+      testPlan: testPlanSchema,
+      testClass: testClassSchema,
+      testMethod: testMethodSchema,
+      codeCoverage: codeCoverageSchema,
+      resultBundlePath: resultBundlePathSchema,
+      retryOnFailure: retryOnFailureSchema,
+      arch: archSchema,
+    },
+    async (params: Params) => {
+      // Validate required parameters
+      const projectValidation = validateRequiredParam('projectPath', params.projectPath);
+      if (!projectValidation.isValid) return projectValidation.errorResponse!;
+
+      const schemeValidation = validateRequiredParam('scheme', params.scheme);
+      if (!schemeValidation.isValid) return schemeValidation.errorResponse!;
+
+      // Build extra args for test-specific options
+      const testExtraArgs = [...(params.extraArgs || [])];
+      
+      if (params.testPlan) {
+        testExtraArgs.push('-testPlan', params.testPlan);
+      }
+      
+      if (params.testClass) {
+        testExtraArgs.push('-only-testing', params.testClass);
+      }
+      
+      if (params.testMethod) {
+        testExtraArgs.push('-only-testing', params.testMethod);
+      }
+      
+      if (params.codeCoverage) {
+        testExtraArgs.push('-enableCodeCoverage', 'YES');
+      }
+      
+      if (params.resultBundlePath) {
+        testExtraArgs.push('-resultBundlePath', params.resultBundlePath);
+      }
+      
+      if (params.retryOnFailure) {
+        testExtraArgs.push('-retry-tests-on-failure');
+      }
+
+      // Add architecture-specific destination if arch provided
+      if (params.arch) {
+        testExtraArgs.push('-destination', `platform=macOS,arch=${params.arch}`);
+      }
+
+      return executeXcodeBuildCommand(
+        {
+          ...params,
+          configuration: params.configuration ?? 'Debug',
+          extraArgs: testExtraArgs,
+        },
+        {
+          platform: XcodePlatform.macOS,
+          logPrefix: 'macOS Test',
+        },
+        params.preferXcodebuild ?? false,
+        'test',
+      );
+    },
+  );
+}
+
+// Register all macOS test tools
+export function registerMacOSTestTools(server: McpServer): void {
+  registerMacOSTestWorkspaceTool(server);
+  registerMacOSTestProjectTool(server);
+}

--- a/src/utils/register-tools.ts
+++ b/src/utils/register-tools.ts
@@ -21,6 +21,14 @@ import {
 // Import iOS device build tools
 import { registerIOSDeviceBuildTools } from '../tools/build_ios_device.js';
 
+// Import test tools
+import { registerIOSSimulatorTestTools } from '../tools/test_ios_simulator.js';
+import { registerIOSDeviceTestTools } from '../tools/test_ios_device.js';
+import { registerMacOSTestTools } from '../tools/test_macos.js';
+
+// Import device discovery tools
+import { registerListIOSDevicesTool } from '../tools/device.js';
+
 // Import app path tools
 import {
   registerGetMacOSAppPathWorkspaceTool,
@@ -124,6 +132,11 @@ const toolRegistrations = [
     register: registerListSimulatorsTool,
     groups: [ToolGroup.SIMULATOR_MANAGEMENT, ToolGroup.PROJECT_DISCOVERY],
     envVar: 'XCODEBUILDMCP_TOOL_LIST_SIMULATORS',
+  },
+  {
+    register: registerListIOSDevicesTool,
+    groups: [ToolGroup.IOS_DEVICE_WORKFLOW, ToolGroup.PROJECT_DISCOVERY],
+    envVar: 'XCODEBUILDMCP_TOOL_LIST_IOS_DEVICES',
   },
   {
     register: registerShowBuildSettingsWorkspaceTool,
@@ -259,6 +272,23 @@ const toolRegistrations = [
     register: registerIOSDeviceBuildTools,
     groups: [ToolGroup.IOS_DEVICE_WORKFLOW],
     envVar: 'XCODEBUILDMCP_TOOL_IOS_DEVICE_BUILD_TOOLS',
+  },
+
+  // Test tools
+  {
+    register: registerIOSSimulatorTestTools,
+    groups: [ToolGroup.IOS_SIMULATOR_WORKFLOW, ToolGroup.TESTING],
+    envVar: 'XCODEBUILDMCP_TOOL_IOS_SIMULATOR_TEST_TOOLS',
+  },
+  {
+    register: registerIOSDeviceTestTools,
+    groups: [ToolGroup.IOS_DEVICE_WORKFLOW, ToolGroup.TESTING],
+    envVar: 'XCODEBUILDMCP_TOOL_IOS_DEVICE_TEST_TOOLS',
+  },
+  {
+    register: registerMacOSTestTools,
+    groups: [ToolGroup.MACOS_WORKFLOW, ToolGroup.TESTING],
+    envVar: 'XCODEBUILDMCP_TOOL_MACOS_TEST_TOOLS',
   },
 
   // App path tools

--- a/src/utils/tool-groups.ts
+++ b/src/utils/tool-groups.ts
@@ -37,6 +37,9 @@ export enum ToolGroup {
 
   // UI testing and automation
   UI_TESTING = 'XCODEBUILDMCP_GROUP_UI_TESTING',
+
+  // Testing tools (unit tests, UI tests)
+  TESTING = 'XCODEBUILDMCP_GROUP_TESTING',
 }
 
 // Map tool registration functions to their respective groups and individual env var names


### PR DESCRIPTION
- Add iOS device discovery with devicectl/xctrace fallback support
- Implement test runners for iOS simulators (by name/UUID)
- Implement test runners for physical iOS devices
- Add macOS test runner support
- Support test plans, code coverage, and result bundles
- Register all new tools in tool registry and groups

🤖 Generated with [Claude Code](https://claude.ai/code)

fixes #55 
