### PR TITLE
Add XCODEBUILDMCP_ENABLED_WORKFLOWS environment variable for selective workflow loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- **Selective Workflow Loading**: New `XCODEBUILDMCP_ENABLED_WORKFLOWS` environment variable allows loading only specific workflow groups in static mode, reducing context window usage for clients that don't support MCP sampling
+
 ## [v1.11.2] - 2025-08-08
 - Fixed "registerTools is not a function" errors during package upgrades
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,44 @@ Example MCP client configuration:
 }
 ```
 
+### Selective Workflow Loading (Static Mode)
+
+For clients that don't support MCP Sampling but still want to reduce context window usage, you can selectively load only specific workflows using the `XCODEBUILDMCP_ENABLED_WORKFLOWS` environment variable:
+
+```json
+{
+  "mcpServers": {
+    "XcodeBuildMCP": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "xcodebuildmcp@latest"
+      ],
+      "env": {
+        "XCODEBUILDMCP_ENABLED_WORKFLOWS": "simulator,device,project-discovery"
+      }        
+    }
+  }
+}
+```
+
+**Available Workflows:**
+- `device` (14 tools) - iOS Device Development
+- `simulator` (18 tools) - iOS Simulator Development
+- `simulator-management` (7 tools) - Simulator Management
+- `swift-package` (6 tools) - Swift Package Manager
+- `project-discovery` (5 tools) - Project Discovery
+- `macos` (11 tools) - macOS Development
+- `ui-testing` (11 tools) - UI Testing & Automation
+- `logging` (4 tools) - Log Capture & Management
+- `project-scaffolding` (2 tools) - Project Scaffolding
+- `utilities` (1 tool) - Project Utilities
+- `doctor` (1 tool) - System Doctor
+- `discovery` (1 tool) - Dynamic Tool Discovery
+
+> [!NOTE]
+> The `XCODEBUILDMCP_ENABLED_WORKFLOWS` setting only works in Static Mode. If `XCODEBUILDMCP_DYNAMIC_TOOLS=true` is set, the selective workflow setting will be ignored.
+
 ### Usage Example
 
 Once enabled, AI agents automatically discover and load relevant tools based on context. For example, when you mention working on an iOS app or the agent detects iOS development tasks in your workspace, it will automatically use the `discover_tools` tool to load the appropriate simulator and project tools needed for your workflow.


### PR DESCRIPTION
## Summary
Adds support for selective workflow loading in static mode via the `XCODEBUILDMCP_ENABLED_WORKFLOWS` environment variable.

## Problem
Clients that don't support MCP sampling cannot use dynamic tools but still want to reduce context window usage by loading only specific tool workflows.

## Solution
- Added `registerSelectedWorkflows()` function to load only specified workflows
- Modified main server initialization to check for `XCODEBUILDMCP_ENABLED_WORKFLOWS` in static mode
- Updated documentation with usage examples and available workflows

## Usage
```json
{
  "env": {
    "XCODEBUILDMCP_ENABLED_WORKFLOWS": "simulator,device,logging"
  }
}
```

## Testing
- [x] All existing tests pass
- [x] Linting passes
- [x] Build succeeds
- [x] Feature works as expected (tested locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable selective loading of specific workflows in Static Mode via an environment variable, helping reduce resource usage for clients without sampling support.
  * Added startup logs listing the workflows selected when this option is used.

* **Documentation**
  * Added guidance on configuring selective workflow loading, with examples and notes on compatibility (Dynamic Tools require sampling; fallback to Static Mode).
  * Updated CHANGELOG with an Unreleased entry describing the new environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->