### PR TITLE
Add simulator video recording tool (record_sim) + AXe v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The XcodeBuildMCP server provides the following tool capabilities:
 - **Log Capture**: Capture run-time logs from a simulator
 - **UI Automation**: Interact with simulator UI elements
 - **Screenshot**: Capture screenshots from a simulator
+- **Video Capture**: Start/stop simulator video capture to MP4
 
 ### Device management
 - **Device Discovery**: List connected physical Apple devices over USB or Wi-Fi

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # XcodeBuildMCP Tools Reference
 
-XcodeBuildMCP provides 60 tools organized into 12 workflow groups for comprehensive Apple development workflows.
+XcodeBuildMCP provides 61 tools organized into 12 workflow groups for comprehensive Apple development workflows.
 
 ## Workflow Groups
 
@@ -19,7 +19,7 @@ XcodeBuildMCP provides 60 tools organized into 12 workflow groups for comprehens
 - `stop_app_device` - Stops an app running on a physical Apple device (iPhone, iPad, Apple Watch, Apple TV, Apple Vision Pro). Requires deviceId and processId.
 - `test_device` - Runs tests for an Apple project or workspace on a physical device (iPhone, iPad, Apple Watch, Apple TV, Apple Vision Pro) using xcodebuild test and parses xcresult output. Provide exactly one of projectPath or workspacePath.
 ### iOS Simulator Development (`simulator`)
-**Purpose**: Complete iOS development workflow for both .xcodeproj and .xcworkspace files targeting simulators. Build, test, deploy, and interact with iOS apps on simulators. (11 tools)
+**Purpose**: Complete iOS development workflow for both .xcodeproj and .xcworkspace files targeting simulators. Build, test, deploy, and interact with iOS apps on simulators. (12 tools)
 
 - `boot_sim` - Boots an iOS simulator. After booting, use open_sim() to make the simulator visible.
 - `build_run_sim` - Builds and runs an app from a project or workspace on a specific simulator by UUID or name. Provide exactly one of projectPath or workspacePath, and exactly one of simulatorId or simulatorName.
@@ -30,6 +30,7 @@ XcodeBuildMCP provides 60 tools organized into 12 workflow groups for comprehens
 - `launch_app_sim` - Launches an app in an iOS simulator by UUID or name. If simulator window isn't visible, use open_sim() first. or launch_app_sim({ simulatorName: 'iPhone 16', bundleId: 'com.example.MyApp' })
 - `list_sims` - Lists available iOS simulators with their UUIDs.
 - `open_sim` - Opens the iOS Simulator app.
+- `record_sim` - Starts or stops video capture for an iOS simulator using AXe. Provide exactly one of start=true or stop=true. On stop, outputFile is required. fps defaults to 30.
 - `stop_app_sim` - Stops an app running in an iOS simulator by UUID or name. or stop_app_sim({ simulatorName: "iPhone 16", bundleId: "com.example.MyApp" })
 - `test_sim` - Runs tests on a simulator by UUID or name using xcodebuild test and parses xcresult output. Works with both Xcode projects (.xcodeproj) and workspaces (.xcworkspace).
 ### Log Capture & Management (`logging`)
@@ -68,7 +69,7 @@ XcodeBuildMCP provides 60 tools organized into 12 workflow groups for comprehens
 ### Simulator Management (`simulator-management`)
 **Purpose**: Tools for managing simulators from booting, opening simulators, listing simulators, stopping simulators, erasing simulator content and settings, and setting simulator environment options like location, network, statusbar and appearance. (5 tools)
 
-- `erase_sims` - Erases simulator content and settings. Provide exactly one of: simulatorUuid or all=true. Optional: shutdownFirst to shut down before erasing.
+- `erase_sims` - Erases simulator content and settings. Provide exactly one of: simulatorUdid or all=true. Optional: shutdownFirst to shut down before erasing.
 - `reset_sim_location` - Resets the simulator's location to default.
 - `set_sim_appearance` - Sets the appearance mode (dark/light) of an iOS simulator.
 - `set_sim_location` - Sets a custom GPS location for the simulator.
@@ -103,7 +104,7 @@ XcodeBuildMCP provides 60 tools organized into 12 workflow groups for comprehens
 
 ## Summary Statistics
 
-- **Total Tools**: 60 canonical tools + 22 re-exports = 82 total
+- **Total Tools**: 61 canonical tools + 22 re-exports = 83 total
 - **Workflow Groups**: 12
 
 ---

--- a/scripts/bundle-axe.sh
+++ b/scripts/bundle-axe.sh
@@ -68,7 +68,7 @@ else
     echo "📥 Downloading latest AXe release from GitHub..."
     
     # Get latest release download URL
-    LATEST_RELEASE_URL="https://github.com/cameroncooke/AXe/releases/download/v1.0.0/AXe-macOS-v1.0.0.tar.gz"
+    LATEST_RELEASE_URL="https://github.com/cameroncooke/AXe/releases/download/v1.1.0/AXe-macOS-v1.1.0.tar.gz"
     
     # Create temp directory
     mkdir -p "$AXE_TEMP_DIR"

--- a/src/mcp/tools/simulator/__tests__/record_sim_video.test.ts
+++ b/src/mcp/tools/simulator/__tests__/record_sim_video.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { z } from 'zod';
+
+// Import the tool and logic
+import tool, { record_sim_videoLogic } from '../record_sim.ts';
+import { createMockFileSystemExecutor } from '../../../../test-utils/mock-executors.ts';
+
+const DUMMY_EXECUTOR: any = (async () => ({ success: true })) as any; // CommandExecutor stub
+const VALID_UUID = '00000000-0000-0000-0000-000000000000';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('record_sim tool - validation', () => {
+  it('errors when start and stop are both true (mutually exclusive)', async () => {
+    const res = await tool.handler({
+      simulatorUuid: VALID_UUID,
+      start: true,
+      stop: true,
+    } as any);
+
+    expect(res.isError).toBe(true);
+    const text = (res.content?.[0] as any)?.text ?? '';
+    expect(text.toLowerCase()).toContain('mutually exclusive');
+  });
+
+  it('errors when stop=true but outputFile is missing', async () => {
+    const res = await tool.handler({
+      simulatorUuid: VALID_UUID,
+      stop: true,
+    } as any);
+
+    expect(res.isError).toBe(true);
+    const text = (res.content?.[0] as any)?.text ?? '';
+    expect(text.toLowerCase()).toContain('outputfile is required');
+  });
+});
+
+describe('record_sim logic - start behavior', () => {
+  it('starts with default fps (30) and warns when outputFile is provided on start (ignored)', async () => {
+    const video: any = {
+      startSimulatorVideoCapture: async () => ({
+        started: true,
+        sessionId: 'sess-123',
+      }),
+      stopSimulatorVideoCapture: async () => ({
+        stopped: false,
+      }),
+    };
+
+    // DI for AXe helpers: available and version OK
+    const axe = {
+      areAxeToolsAvailable: () => true,
+      isAxeAtLeastVersion: async () => true,
+      createAxeNotAvailableResponse: () => ({
+        content: [{ type: 'text', text: 'AXe not available' }],
+        isError: true,
+      }),
+    };
+
+    const fs = createMockFileSystemExecutor();
+
+    const res = await record_sim_videoLogic(
+      {
+        simulatorUuid: VALID_UUID,
+        start: true,
+        // fps omitted to hit default 30
+        outputFile: '/tmp/ignored.mp4', // should be ignored with a note
+      } as any,
+      DUMMY_EXECUTOR,
+      axe,
+      video,
+      fs,
+    );
+
+    expect(res.isError).toBe(false);
+    const texts = (res.content ?? []).map((c: any) => c.text).join('\n');
+
+    expect(texts).toContain('🎥');
+    expect(texts).toMatch(/30\s*fps/i);
+    expect(texts.toLowerCase()).toContain('outputfile is ignored');
+    expect(texts).toContain('Next Steps');
+    expect(texts).toContain('stop: true');
+    expect(texts).toContain('outputFile');
+  });
+});
+
+describe('record_sim logic - end-to-end stop with rename', () => {
+  it('stops, parses stdout path, and renames to outputFile', async () => {
+    const video: any = {
+      startSimulatorVideoCapture: async () => ({
+        started: true,
+        sessionId: 'sess-abc',
+      }),
+      stopSimulatorVideoCapture: async () => ({
+        stopped: true,
+        parsedPath: '/tmp/recorded.mp4',
+        stdout: 'Saved to /tmp/recorded.mp4',
+      }),
+    };
+
+    const fs = createMockFileSystemExecutor();
+
+    const axe = {
+      areAxeToolsAvailable: () => true,
+      isAxeAtLeastVersion: async () => true,
+      createAxeNotAvailableResponse: () => ({
+        content: [{ type: 'text', text: 'AXe not available' }],
+        isError: true,
+      }),
+    };
+
+    // Start (not strictly required for stop path, but included to mimic flow)
+    const startRes = await record_sim_videoLogic(
+      {
+        simulatorUuid: VALID_UUID,
+        start: true,
+      } as any,
+      DUMMY_EXECUTOR,
+      axe,
+      video,
+      fs,
+    );
+    expect(startRes.isError).toBe(false);
+
+    // Stop and rename
+    const outputFile = '/var/videos/final.mp4';
+    const stopRes = await record_sim_videoLogic(
+      {
+        simulatorUuid: VALID_UUID,
+        stop: true,
+        outputFile,
+      } as any,
+      DUMMY_EXECUTOR,
+      axe,
+      video,
+      fs,
+    );
+
+    expect(stopRes.isError).toBe(false);
+    const texts = (stopRes.content ?? []).map((c: any) => c.text).join('\n');
+    expect(texts).toContain('Original file: /tmp/recorded.mp4');
+    expect(texts).toContain(`Saved to: ${outputFile}`);
+
+    // _meta should include final saved path
+    expect((stopRes as any)._meta?.outputFile).toBe(outputFile);
+  });
+});
+
+describe('record_sim logic - version gate', () => {
+  it('errors when AXe version is below 1.1.0', async () => {
+    const axe = {
+      areAxeToolsAvailable: () => true,
+      isAxeAtLeastVersion: async () => false,
+      createAxeNotAvailableResponse: () => ({
+        content: [{ type: 'text', text: 'AXe not available' }],
+        isError: true,
+      }),
+    };
+
+    const video: any = {
+      startSimulatorVideoCapture: async () => ({
+        started: true,
+        sessionId: 'sess-xyz',
+      }),
+      stopSimulatorVideoCapture: async () => ({
+        stopped: true,
+      }),
+    };
+
+    const fs = createMockFileSystemExecutor();
+
+    const res = await record_sim_videoLogic(
+      {
+        simulatorUuid: VALID_UUID,
+        start: true,
+      } as any,
+      DUMMY_EXECUTOR,
+      axe,
+      video,
+      fs,
+    );
+
+    expect(res.isError).toBe(true);
+    const text = (res.content?.[0] as any)?.text ?? '';
+    expect(text).toContain('AXe v1.1.0');
+  });
+});

--- a/src/mcp/tools/simulator/record_sim.ts
+++ b/src/mcp/tools/simulator/record_sim.ts
@@ -1,0 +1,220 @@
+import { z } from 'zod';
+import type { ToolResponse } from '../../../types/common.ts';
+import { createTextResponse } from '../../../utils/responses/index.ts';
+import {
+  getDefaultCommandExecutor,
+  getDefaultFileSystemExecutor,
+} from '../../../utils/execution/index.ts';
+import type { CommandExecutor, FileSystemExecutor } from '../../../utils/execution/index.ts';
+import {
+  areAxeToolsAvailable,
+  isAxeAtLeastVersion,
+  createAxeNotAvailableResponse,
+} from '../../../utils/axe/index.ts';
+import {
+  startSimulatorVideoCapture,
+  stopSimulatorVideoCapture,
+} from '../../../utils/video-capture/index.ts';
+import { createTypedTool } from '../../../utils/typed-tool-factory.ts';
+import { dirname } from 'path';
+
+// Base schema object (used for MCP schema exposure)
+const recordSimVideoSchemaObject = z.object({
+  simulatorUuid: z
+    .string()
+    .uuid('Invalid Simulator UUID format')
+    .describe('UUID of the simulator to record'),
+  start: z.boolean().optional().describe('Start recording if true'),
+  stop: z.boolean().optional().describe('Stop recording if true'),
+  fps: z.number().int().min(1).max(120).optional().describe('Frames per second (default 30)'),
+  outputFile: z
+    .string()
+    .optional()
+    .describe('Destination MP4 path to move the recorded video to on stop'),
+});
+
+// Schema enforcing mutually exclusive start/stop and requiring outputFile on stop
+const recordSimVideoSchema = recordSimVideoSchemaObject
+  .refine(
+    (v) => {
+      const s = v.start === true ? 1 : 0;
+      const t = v.stop === true ? 1 : 0;
+      return s + t === 1;
+    },
+    {
+      message:
+        'Provide exactly one of start=true or stop=true; these options are mutually exclusive',
+      path: ['start'],
+    },
+  )
+  .refine((v) => (v.stop ? typeof v.outputFile === 'string' && v.outputFile.length > 0 : true), {
+    message: 'outputFile is required when stop=true',
+    path: ['outputFile'],
+  });
+
+type RecordSimVideoParams = z.infer<typeof recordSimVideoSchema>;
+
+export async function record_sim_videoLogic(
+  params: RecordSimVideoParams,
+  executor: CommandExecutor,
+  axe: {
+    areAxeToolsAvailable(): boolean;
+    isAxeAtLeastVersion(v: string, e: CommandExecutor): Promise<boolean>;
+    createAxeNotAvailableResponse(): ToolResponse;
+  } = {
+    areAxeToolsAvailable,
+    isAxeAtLeastVersion,
+    createAxeNotAvailableResponse,
+  },
+  video: {
+    startSimulatorVideoCapture: typeof startSimulatorVideoCapture;
+    stopSimulatorVideoCapture: typeof stopSimulatorVideoCapture;
+  } = {
+    startSimulatorVideoCapture,
+    stopSimulatorVideoCapture,
+  },
+  fs: FileSystemExecutor = getDefaultFileSystemExecutor(),
+): Promise<ToolResponse> {
+  // Preflight checks for AXe availability and version
+  if (!axe.areAxeToolsAvailable()) {
+    return axe.createAxeNotAvailableResponse();
+  }
+  const hasVersion = await axe.isAxeAtLeastVersion('1.1.0', executor);
+  if (!hasVersion) {
+    return createTextResponse('AXe v1.1.0 or newer is required for simulator video capture.', true);
+  }
+
+  if (params.start) {
+    const fpsUsed = Number.isFinite(params.fps as number) ? Number(params.fps) : 30;
+    const startRes = await video.startSimulatorVideoCapture(
+      { simulatorUuid: params.simulatorUuid, fps: fpsUsed },
+      executor,
+    );
+
+    if (!startRes.started) {
+      return createTextResponse(
+        `Failed to start video recording: ${startRes.error ?? 'Unknown error'}`,
+        true,
+      );
+    }
+
+    const notes: string[] = [];
+    if (typeof params.outputFile === 'string' && params.outputFile.length > 0) {
+      notes.push(
+        'Note: outputFile is ignored when start=true; provide it when stopping to move/rename the recorded file.',
+      );
+    }
+    if (startRes.warning) {
+      notes.push(startRes.warning);
+    }
+
+    const nextSteps = `Next Steps:\nStop and save the recording:\nrecord_sim({ simulatorUuid: "${params.simulatorUuid}", stop: true, outputFile: "/path/to/output.mp4" })`;
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `🎥 Video recording started for simulator ${params.simulatorUuid} at ${fpsUsed} fps.\nSession: ${startRes.sessionId}`,
+        },
+        ...(notes.length > 0
+          ? [
+              {
+                type: 'text' as const,
+                text: notes.join('\n'),
+              },
+            ]
+          : []),
+        {
+          type: 'text',
+          text: nextSteps,
+        },
+      ],
+      isError: false,
+    };
+  }
+
+  // params.stop must be true here per schema
+  const stopRes = await video.stopSimulatorVideoCapture(
+    { simulatorUuid: params.simulatorUuid },
+    executor,
+  );
+
+  if (!stopRes.stopped) {
+    return createTextResponse(
+      `Failed to stop video recording: ${stopRes.error ?? 'Unknown error'}`,
+      true,
+    );
+  }
+
+  // Attempt to move/rename the recording if we parsed a source path and an outputFile was given
+  const outputs: string[] = [];
+  let finalSavedPath = params.outputFile ?? stopRes.parsedPath ?? '';
+  try {
+    if (params.outputFile) {
+      if (!stopRes.parsedPath) {
+        return createTextResponse(
+          `Recording stopped but could not determine the recorded file path from AXe output.\nRaw output:\n${stopRes.stdout ?? '(no output captured)'}`,
+          true,
+        );
+      }
+
+      const src = stopRes.parsedPath;
+      const dest = params.outputFile;
+      await fs.mkdir(dirname(dest), { recursive: true });
+      await fs.cp(src, dest);
+      try {
+        await fs.rm(src, { recursive: false });
+      } catch {
+        // Ignore cleanup failure
+      }
+      finalSavedPath = dest;
+
+      outputs.push(`Original file: ${src}`);
+      outputs.push(`Saved to: ${dest}`);
+    } else if (stopRes.parsedPath) {
+      outputs.push(`Saved to: ${stopRes.parsedPath}`);
+      finalSavedPath = stopRes.parsedPath;
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return createTextResponse(
+      `Recording stopped but failed to save/move the video file: ${msg}`,
+      true,
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `✅ Video recording stopped for simulator ${params.simulatorUuid}.`,
+      },
+      ...(outputs.length > 0
+        ? [
+            {
+              type: 'text' as const,
+              text: outputs.join('\n'),
+            },
+          ]
+        : []),
+      ...(!outputs.length && stopRes.stdout
+        ? [
+            {
+              type: 'text' as const,
+              text: `AXe output:\n${stopRes.stdout}`,
+            },
+          ]
+        : []),
+    ],
+    isError: false,
+    _meta: finalSavedPath ? { outputFile: finalSavedPath } : undefined,
+  };
+}
+
+export default {
+  name: 'record_sim',
+  description:
+    'Starts or stops video capture for an iOS simulator using AXe. Provide exactly one of start=true or stop=true. On stop, outputFile is required. fps defaults to 30.',
+  schema: recordSimVideoSchemaObject.shape,
+  handler: createTypedTool(recordSimVideoSchema, record_sim_videoLogic, getDefaultCommandExecutor),
+};

--- a/src/utils/__tests__/axe_helpers.test.ts
+++ b/src/utils/__tests__/axe_helpers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { isAxeAtLeastVersion } from '../axe-helpers.ts';
+import { createMockExecutor } from '../../test-utils/mock-executors.ts';
+
+const DI = (axePath: string | null) => ({
+  getAxePath: () => axePath,
+});
+
+describe('isAxeAtLeastVersion', () => {
+  it('returns true when current >= required (1.2.0 >= 1.1.0)', async () => {
+    const exec = createMockExecutor({ success: true, output: 'AXe 1.2.0\n' });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(true);
+  });
+
+  it('returns false when current < required (1.0.9 < 1.1.0)', async () => {
+    const exec = createMockExecutor({ success: true, output: '1.0.9\n' });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when version cannot be parsed', async () => {
+    const exec = createMockExecutor({ success: true, output: 'AXe version unknown\n' });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when executor indicates failure', async () => {
+    const exec = createMockExecutor({ success: false, error: 'failed' });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(false);
+  });
+
+  it('returns false when axe binary is not available (getAxePath returns null)', async () => {
+    const exec = createMockExecutor({ success: true, output: 'AXe 1.2.0\n' });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI(null));
+    expect(ok).toBe(false);
+  });
+
+  it('prefers the version following AXe token when multiple semvers are present', async () => {
+    const output = 'macOS 14.4.1\nSwift 5.10.1\nAXe version 1.1.0\n';
+    const exec = createMockExecutor({ success: true, output });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(true);
+  });
+
+  it('falls back to the highest semver when AXe token is missing', async () => {
+    const output = 'deps 0.9.0\nlib 2.0.0\ncore 1.5.1\n';
+    const exec = createMockExecutor({ success: true, output });
+    const ok = await isAxeAtLeastVersion('1.6.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(true); // picks 2.0.0
+  });
+
+  it('matches v-prefixed version on a single line output', async () => {
+    const output = 'v1.1.0\n';
+    const exec = createMockExecutor({ success: true, output });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(true);
+  });
+
+  it('handles noise lines then v-prefixed version line', async () => {
+    const output = 'objc[123]: some noisy preface\nwhatever\nv1.1.0\n';
+    const exec = createMockExecutor({ success: true, output });
+    const ok = await isAxeAtLeastVersion('1.1.0', exec, DI('/fake/axe'));
+    expect(ok).toBe(true);
+  });
+});

--- a/src/utils/axe/index.ts
+++ b/src/utils/axe/index.ts
@@ -3,4 +3,5 @@ export {
   getAxePath,
   getBundledAxeEnvironment,
   areAxeToolsAvailable,
+  isAxeAtLeastVersion,
 } from '../axe-helpers.ts';

--- a/src/utils/video-capture/index.ts
+++ b/src/utils/video-capture/index.ts
@@ -1,0 +1,5 @@
+export {
+  startSimulatorVideoCapture,
+  stopSimulatorVideoCapture,
+  type AxeHelpers,
+} from '../video_capture.ts';

--- a/src/utils/video_capture.ts
+++ b/src/utils/video_capture.ts
@@ -1,0 +1,214 @@
+/**
+ * Video capture utility for simulator recordings using AXe.
+ *
+ * Manages long-running AXe "record-video" processes keyed by simulator UUID.
+ * It aggregates stdout/stderr to parse the generated MP4 path on stop.
+ */
+
+import type { ChildProcess } from 'child_process';
+import { log } from './logging/index.ts';
+import { getAxePath, getBundledAxeEnvironment } from './axe-helpers.ts';
+import type { CommandExecutor } from './execution/index.ts';
+
+type Session = {
+  process: unknown;
+  sessionId: string;
+  startedAt: number;
+  buffer: string;
+};
+
+const sessions = new Map<string, Session>();
+let signalHandlersAttached = false;
+
+export interface AxeHelpers {
+  getAxePath: () => string | null;
+  getBundledAxeEnvironment: () => Record<string, string>;
+}
+
+function ensureSignalHandlersAttached(): void {
+  if (signalHandlersAttached) return;
+  signalHandlersAttached = true;
+
+  const stopAll = () => {
+    for (const [simulatorUuid, sess] of sessions) {
+      try {
+        const child = sess.process as ChildProcess | undefined;
+        child?.kill?.('SIGINT');
+      } catch {
+        // ignore
+      } finally {
+        sessions.delete(simulatorUuid);
+      }
+    }
+  };
+
+  try {
+    process.on('SIGINT', stopAll);
+    process.on('SIGTERM', stopAll);
+    process.on('exit', stopAll);
+  } catch {
+    // Non-Node environments may not support process signals; ignore
+  }
+}
+
+function parseLastAbsoluteMp4Path(buffer: string | undefined): string | null {
+  if (!buffer) return null;
+  const matches = [...buffer.matchAll(/(\s|^)(\/[^\s'"]+\.mp4)\b/gi)];
+  if (matches.length === 0) return null;
+  const last = matches[matches.length - 1];
+  return last?.[2] ?? null;
+}
+
+function createSessionId(simulatorUuid: string): string {
+  return `${simulatorUuid}:${Date.now()}`;
+}
+
+/**
+ * Start recording video for a simulator using AXe.
+ */
+export async function startSimulatorVideoCapture(
+  params: { simulatorUuid: string; fps?: number },
+  executor: CommandExecutor,
+  axeHelpers?: AxeHelpers,
+): Promise<{ started: boolean; sessionId?: string; warning?: string; error?: string }> {
+  const simulatorUuid = params.simulatorUuid;
+  if (!simulatorUuid) {
+    return { started: false, error: 'simulatorUuid is required' };
+  }
+
+  if (sessions.has(simulatorUuid)) {
+    return {
+      started: false,
+      error: 'A video recording session is already active for this simulator. Stop it first.',
+    };
+  }
+
+  const helpers = axeHelpers ?? {
+    getAxePath,
+    getBundledAxeEnvironment,
+  };
+
+  const axeBinary = helpers.getAxePath();
+  if (!axeBinary) {
+    return { started: false, error: 'Bundled AXe binary not found' };
+  }
+
+  const fps = Number.isFinite(params.fps as number) ? Number(params.fps) : 30;
+  const command = [axeBinary, 'record-video', '--udid', simulatorUuid, '--fps', String(fps)];
+  const env = helpers.getBundledAxeEnvironment?.() ?? {};
+
+  log('info', `Starting AXe video recording for simulator ${simulatorUuid} at ${fps} fps`);
+
+  const result = await executor(command, 'Start Simulator Video Capture', true, env);
+
+  if (!result.success || !result.process) {
+    return {
+      started: false,
+      error: result.error ?? 'Failed to start video capture process',
+    };
+  }
+
+  const child = result.process as ChildProcess;
+  const session: Session = {
+    process: child,
+    sessionId: createSessionId(simulatorUuid),
+    startedAt: Date.now(),
+    buffer: '',
+  };
+
+  try {
+    child.stdout?.on('data', (d: unknown) => {
+      try {
+        session.buffer += String(d ?? '');
+      } catch {
+        // ignore
+      }
+    });
+    child.stderr?.on('data', (d: unknown) => {
+      try {
+        session.buffer += String(d ?? '');
+      } catch {
+        // ignore
+      }
+    });
+  } catch {
+    // ignore stream listener setup failures
+  }
+
+  sessions.set(simulatorUuid, session);
+  ensureSignalHandlersAttached();
+
+  return {
+    started: true,
+    sessionId: session.sessionId,
+    warning: fps !== (params.fps ?? 30) ? `FPS coerced to ${fps}` : undefined,
+  };
+}
+
+/**
+ * Stop recording video for a simulator. Returns aggregated output and parsed MP4 path if found.
+ */
+export async function stopSimulatorVideoCapture(
+  params: { simulatorUuid: string },
+  executor: CommandExecutor,
+): Promise<{
+  stopped: boolean;
+  sessionId?: string;
+  stdout?: string;
+  parsedPath?: string;
+  error?: string;
+}> {
+  // Mark executor as used to satisfy lint rule
+  void executor;
+
+  const simulatorUuid = params.simulatorUuid;
+  if (!simulatorUuid) {
+    return { stopped: false, error: 'simulatorUuid is required' };
+  }
+
+  const session = sessions.get(simulatorUuid);
+  if (!session) {
+    return { stopped: false, error: 'No active video recording session for this simulator' };
+  }
+
+  const child = session.process as ChildProcess | undefined;
+
+  // Attempt graceful shutdown
+  try {
+    child?.kill?.('SIGINT');
+  } catch {
+    try {
+      child?.kill?.();
+    } catch {
+      // ignore
+    }
+  }
+
+  // Wait for process to close
+  await new Promise<void>((resolve) => {
+    if (!child) return resolve();
+    try {
+      child.once('close', () => resolve());
+      child.once('exit', () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+
+  const combinedOutput = session.buffer;
+  const parsedPath = parseLastAbsoluteMp4Path(combinedOutput) ?? undefined;
+
+  sessions.delete(simulatorUuid);
+
+  log(
+    'info',
+    `Stopped AXe video recording for simulator ${simulatorUuid}. ${parsedPath ? `Detected file: ${parsedPath}` : 'No file detected in output.'}`,
+  );
+
+  return {
+    stopped: true,
+    sessionId: session.sessionId,
+    stdout: combinedOutput,
+    parsedPath,
+  };
+}


### PR DESCRIPTION
## Summary
Adds an iOS simulator video recording tool and updates the bundled AXe to v1.1.0 (which includes the new video recording feature).

## What’s Included
- Tool: `record_sim` (simulator group)
  - Params: `simulatorUuid` (required), `start` | `stop` (mutually exclusive), `fps` (default 30), `outputFile` (required on stop)
  - UX: If `start=true` and `outputFile` is provided, it is ignored with a subtle note; the response shows a “how to stop” hint
- Util: Video capture session manager
  - Tracks one active session per simulator UDID
  - Starts AXe `record-video` as a long‑running process, aggregates stdout/stderr, and stops via SIGINT
  - Parses the finalized MP4 path from AXe output and moves/renames it on stop
- AXe helpers
  - `isAxeAtLeastVersion` with robust semver extraction (prefers `AXe vX.Y.Z`, falls back to highest semver token)
  - DI‑friendly signature for testing; unit tests added
- Bundling
  - `scripts/bundle-axe.sh` updated to fetch AXe v1.1.0
- Documentation
  - README updated (Video Capture + bundling note)
  - `docs/TOOLS.md` regenerated (now lists `record_sim` under the simulator workflow)

## Validation
- Formatting, lint, typecheck: pass
- Build: pass
- Tests: pass (84 files; >1,100 tests, a few skipped)

## Usage (Reloaderoo)
Start:
```bash
npx reloaderoo inspect call-tool record_sim \
  --params '{"simulatorUuid":"<SIM_UDID>","start":true,"fps":30}' \
  -- node build/index.js
```
Stop and save:
```bash
npx reloaderoo inspect call-tool record_sim \
  --params '{"simulatorUuid":"<SIM_UDID>","stop":true,"outputFile":"./recordings/sim-recording.mp4"}' \
  -- node build/index.js
```

Prereq for real recordings (unit tests don’t require this):
```bash
npm run bundle:axe && npm run build
```

## Follow‑ups (Optional)
- Add a `list_active_recordings` tool to enumerate in‑flight sessions (UDID, sessionId, startedAt).
