### PR TITLE
Change flags from -H to -e in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To use XcodeBuildMCP with [Claude Code](https://code.anthropic.com), you can add
 claude mcp add XcodeBuildMCP npx xcodebuildmcp@latest
 
 # Or with environment variables
-claude mcp add XcodeBuildMCP npx xcodebuildmcp@latest -H INCREMENTAL_BUILDS_ENABLED=false -H XCODEBUILDMCP_SENTRY_DISABLED=false
+claude mcp add XcodeBuildMCP npx xcodebuildmcp@latest -e INCREMENTAL_BUILDS_ENABLED=false -e XCODEBUILDMCP_SENTRY_DISABLED=false
 ```
 
 ##### Smithery


### PR DESCRIPTION
It looks like the `-H` is being ignored, specially for commands with workflows. `-e` is working perfectly. Took me a bit to figure it out.

```bash
claude mcp add XcodeBuildMCP npx xcodebuildmcp@latest -e XCODEBUILDMCP_ENABLED_WORKFLOWS=simulator,project-discovery,logging
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI example to use short-form environment flags (-e) instead of legacy host flags (-H).
  * Aligned command syntax in the docs with current CLI conventions for clarity.
  * No functional changes to the product; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README to use `-e` environment flags instead of `-H` in the Claude Code CLI example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae0b61560b11ba86d523bcd05507421aeb5ff12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->